### PR TITLE
Rename name to item

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports.Bounded = function(data, maxWeight) {
     var val = 0;
     for (var i = 0; i < best.length; i++) {
         if (0 == best[i]) continue;
-        result[result.length] = { count: best[i], item: data[i].name };
+        result[result.length] = { count: best[i], item: data[i].item };
         wgt += best[i] * data[i].weight;
         val += best[i] * data[i].value;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -5,11 +5,11 @@ var assert = require('assert');
 describe('Problem of the coffee machine', function() {
     describe('Return the maximum number of coins with change 1x1, 1x2, 1x3, 1x4 and 1x5', function() {
         var list = [
-            { name: '1', weight: 1, value: 1, pieces: 1 },
-            { name: '2', weight: 2, value: 2, pieces: 1 },
-            { name: '3', weight: 3, value: 3, pieces: 1 },
-            { name: '4', weight: 4, value: 4, pieces: 1 },
-            { name: '5', weight: 5, value: 5, pieces: 1 },
+            { item: '1', weight: 1, value: 1, pieces: 1 },
+            { item: '2', weight: 2, value: 2, pieces: 1 },
+            { item: '3', weight: 3, value: 3, pieces: 1 },
+            { item: '4', weight: 4, value: 4, pieces: 1 },
+            { item: '5', weight: 5, value: 5, pieces: 1 },
         ];
 
         it('If ask 8 should be 1x1, 1x3 and 1x4', function() {
@@ -30,11 +30,11 @@ describe('Problem of the coffee machine', function() {
 
 describe('Return the maximum number of coins with change 2x1, 2x2, 2x3, 2x4 and 2x5', function() {
     var list = [
-        { name: '1', weight: 1, value: 1, pieces: 2 },
-        { name: '2', weight: 2, value: 2, pieces: 2 },
-        { name: '3', weight: 3, value: 3, pieces: 2 },
-        { name: '4', weight: 4, value: 4, pieces: 2 },
-        { name: '5', weight: 5, value: 5, pieces: 2 },
+        { item: '1', weight: 1, value: 1, pieces: 2 },
+        { item: '2', weight: 2, value: 2, pieces: 2 },
+        { item: '3', weight: 3, value: 3, pieces: 2 },
+        { item: '4', weight: 4, value: 4, pieces: 2 },
+        { item: '5', weight: 5, value: 5, pieces: 2 },
     ];
 
     it('If ask 8 should be 1x1, 1x3 and 1x4', function() {
@@ -56,28 +56,28 @@ describe('Return the maximum number of coins with change 2x1, 2x2, 2x3, 2x4 and 
 describe('A tourist wants to make a good trip at the weekend with his friends. They will go to the mountains to see the wonders of nature. So he needs some items during the trip. Food, clothing, etc. He has a good knapsack for carrying the things, but he knows that he can carry only 4 kg weight in his knapsack, because they will make the trip from morning to evening. He creates a list of what he wants to bring for the trip, but the total weight of all items is too much. He adds a value to each item. The value represents how important the thing for the tourist. The list contains which items are the wanted things for the trip, what is the weight and value of an item, and how many units does he have from each items. ', function() {
     describe('The tourist can choose to take any combination of items from the list, and some number of each item is available (see the column "Piece(s)" of the list!). He may not cut the items, so he can only take whole units of any item.', function() {
         var list = [
-            { name: 'map', weight: 9, value: 150, pieces: 1 },
-            { name: 'compass', weight: 13, value: 35, pieces: 1 },
-            { name: 'water', weight: 153, value: 200, pieces: 2 },
-            { name: 'sandwich', weight: 50, value: 60, pieces: 2 },
-            { name: 'glucose', weight: 15, value: 60, pieces: 2 },
-            { name: 'tin', weight: 68, value: 45, pieces: 3 },
-            { name: 'banana', weight: 27, value: 60, pieces: 3 },
-            { name: 'apple', weight: 39, value: 40, pieces: 3 },
-            { name: 'cheese', weight: 23, value: 30, pieces: 1 },
-            { name: 'beer', weight: 52, value: 10, pieces: 3 },
-            { name: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
-            { name: 'camera', weight: 32, value: 30, pieces: 1 },
-            { name: 'T-shirt', weight: 24, value: 15, pieces: 2 },
-            { name: 'trousers', weight: 48, value: 10, pieces: 2 },
-            { name: 'umbrella', weight: 73, value: 40, pieces: 1 },
-            { name: 'waterproof, trousers', weight: 42, value: 70, pieces: 1 },
-            { name: 'waterproof, overclothes', weight: 43, value: 75, pieces: 1 },
-            { name: 'note-case', weight: 22, value: 80, pieces: 1 },
-            { name: 'sunglasses', weight: 7, value: 20, pieces: 1 },
-            { name: 'towel', weight: 18, value: 12, pieces: 2 },
-            { name: 'socks', weight: 4, value: 50, pieces: 1 },
-            { name: 'book', weight: 30, value: 10, pieces: 2 }
+            { item: 'map', weight: 9, value: 150, pieces: 1 },
+            { item: 'compass', weight: 13, value: 35, pieces: 1 },
+            { item: 'water', weight: 153, value: 200, pieces: 2 },
+            { item: 'sandwich', weight: 50, value: 60, pieces: 2 },
+            { item: 'glucose', weight: 15, value: 60, pieces: 2 },
+            { item: 'tin', weight: 68, value: 45, pieces: 3 },
+            { item: 'banana', weight: 27, value: 60, pieces: 3 },
+            { item: 'apple', weight: 39, value: 40, pieces: 3 },
+            { item: 'cheese', weight: 23, value: 30, pieces: 1 },
+            { item: 'beer', weight: 52, value: 10, pieces: 3 },
+            { item: 'suntan, cream', weight: 11, value: 70, pieces: 1 },
+            { item: 'camera', weight: 32, value: 30, pieces: 1 },
+            { item: 'T-shirt', weight: 24, value: 15, pieces: 2 },
+            { item: 'trousers', weight: 48, value: 10, pieces: 2 },
+            { item: 'umbrella', weight: 73, value: 40, pieces: 1 },
+            { item: 'waterproof, trousers', weight: 42, value: 70, pieces: 1 },
+            { item: 'waterproof, overclothes', weight: 43, value: 75, pieces: 1 },
+            { item: 'note-case', weight: 22, value: 80, pieces: 1 },
+            { item: 'sunglasses', weight: 7, value: 20, pieces: 1 },
+            { item: 'towel', weight: 18, value: 12, pieces: 2 },
+            { item: 'socks', weight: 4, value: 50, pieces: 1 },
+            { item: 'book', weight: 30, value: 10, pieces: 2 }
         ];
 
         describe('Which items does the tourist carry in his knapsack so that their total weight does not exceed 4 kg, and their total value is maximised?', function() {


### PR DESCRIPTION
This PR renames `name` to `item`.

I just found your module and I really like it, but in my case (and others probably) my `name` elements was objects. So since the returned result uses the terminology `items` and `item` I thought it was better if the input was renamed to the same.